### PR TITLE
Snapshot refactor

### DIFF
--- a/android/src/main/kotlin/com/example/flutter_sceneview/ar/ARScene.kt
+++ b/android/src/main/kotlin/com/example/flutter_sceneview/ar/ARScene.kt
@@ -208,12 +208,6 @@ class ARScene(
     }
 
     private fun onTakeSnapshot(result: MethodChannel.Result) {
-        val activity = sceneView.context as? Activity
-        if (activity == null) {
-            result.error("FAILED_SNAPSHOT_ERROR", "Context is not an Activity", null)
-            return
-        }
-
         sceneView.planeRenderer.isVisible = false
 
         // Creation of snapshot is delayed so we ensure that the plane has been hidden
@@ -229,7 +223,7 @@ class ARScene(
                         }
                     }
                 } else {
-                    result.error("FAILED_SNAPSHOT_ERROR", "PixelCopy failed", null)
+                    result.error("FAILED_SNAPSHOT_ERROR", "PixelCopy failed to create snapshot", null)
                 }
             }
         }

--- a/android/src/main/kotlin/com/example/flutter_sceneview/ar/ARScene.kt
+++ b/android/src/main/kotlin/com/example/flutter_sceneview/ar/ARScene.kt
@@ -1,9 +1,11 @@
 package com.example.flutter_sceneview.ar
 
-import android.media.Image
+import android.app.Activity
 import android.content.Context
 import android.content.res.AssetManager
 import android.util.Log
+import android.view.SurfaceView
+import androidx.core.view.postDelayed
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.example.flutter_sceneview.utils.SnapshotUtils
@@ -13,11 +15,16 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import com.google.android.filament.EntityManager
 import com.google.android.filament.LightManager
+import com.google.android.filament.Material
 import com.google.android.filament.Skybox
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlin.math.cos
 import kotlin.math.sin
 
@@ -201,22 +208,30 @@ class ARScene(
     }
 
     private fun onTakeSnapshot(result: MethodChannel.Result) {
-        try {
-            val image: Image? = sceneView.frame?.acquireCameraImage()
-            if (image != null) {
-                val bitmap = SnapshotUtils.convertYUVToBitmap(image)
-                image.close()
+        val activity = sceneView.context as? Activity
+        if (activity == null) {
+            result.error("FAILED_SNAPSHOT_ERROR", "Context is not an Activity", null)
+            return
+        }
 
-                val portraitBitmap =
-                    SnapshotUtils.rotateToPortrait(bitmap)
-                val scaledBitmap =
-                    SnapshotUtils.scaleBitmap(portraitBitmap, sceneView.width, sceneView.height)
-                val byteArray = SnapshotUtils.bitmapToByteArray(scaledBitmap)
+        sceneView.planeRenderer.isVisible = false
 
-                result.success(byteArray)
+        // Creation of snapshot is delayed so we ensure that the plane has been hidden
+        sceneView.postDelayed(20) {
+            SnapshotUtils.pixelCopyBitmap(sceneView as SurfaceView) { bitmap ->
+                if (bitmap != null) {
+                    CoroutineScope(Dispatchers.Default).launch {
+                        val byteArray = SnapshotUtils.bitmapToByteArray(bitmap)
+
+                        withContext(Dispatchers.Main) {
+                            sceneView.planeRenderer.isVisible = true
+                            result.success(byteArray)
+                        }
+                    }
+                } else {
+                    result.error("FAILED_SNAPSHOT_ERROR", "PixelCopy failed", null)
+                }
             }
-        } catch (e: Exception) {
-            result.error("FAILED_SNAPSHOT_ERROR", e.message ?: "Unknown error", null)
         }
     }
 }

--- a/android/src/main/kotlin/com/example/flutter_sceneview/utils/SnapshotUtils.kt
+++ b/android/src/main/kotlin/com/example/flutter_sceneview/utils/SnapshotUtils.kt
@@ -1,73 +1,32 @@
 package com.example.flutter_sceneview.utils
 
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
-import android.graphics.ImageFormat
-import android.graphics.Matrix
-import android.graphics.Rect
-import android.graphics.YuvImage
-import android.media.Image
+import android.os.Handler
+import android.os.Looper
+import android.view.Choreographer
+import android.view.PixelCopy
+import android.view.SurfaceView
 import java.io.ByteArrayOutputStream
-import androidx.core.graphics.scale
+import androidx.core.graphics.createBitmap
 
 object SnapshotUtils {
-    fun bitmapToByteArray(bitmap: Bitmap): ByteArray {
+    fun pixelCopyBitmap(sceneView: SurfaceView, onResult: (Bitmap?) -> Unit) {
+        val bitmap = createBitmap(sceneView.width, sceneView.height)
+
+        Choreographer.getInstance().postFrameCallback {
+            PixelCopy.request(sceneView, bitmap, { copyResult ->
+                if (copyResult == PixelCopy.SUCCESS) {
+                    onResult(bitmap)
+                } else {
+                    onResult(null)
+                }
+            }, Handler(Looper.getMainLooper()))
+        }
+    }
+
+    fun bitmapToByteArray(bitmap: Bitmap, bitmapQuality: Int = 100): ByteArray {
         val outputStream = ByteArrayOutputStream()
-        bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
+        bitmap.compress(Bitmap.CompressFormat.PNG, bitmapQuality, outputStream)
         return outputStream.toByteArray()
-    }
-
-    fun convertYUVToBitmap(image: Image): Bitmap {
-        val yBuffer = image.planes[0].buffer
-        val uBuffer = image.planes[1].buffer
-        val vBuffer = image.planes[2].buffer
-
-        val ySize = yBuffer.remaining()
-        val uSize = uBuffer.remaining()
-        val vSize = vBuffer.remaining()
-
-        val nv21 = ByteArray(ySize + uSize + vSize)
-
-        // Copy Y data
-        yBuffer.get(nv21, 0, ySize)
-
-        // Copy VU data (VU order for NV21)
-        val chromaRowStride = image.planes[1].rowStride
-        val chromaPixelStride = image.planes[1].pixelStride
-
-        var offset = ySize
-        val width = image.width
-        val height = image.height
-
-        for (row in 0 until height / 2) {
-            for (col in 0 until width / 2) {
-                val vuIndex = row * chromaRowStride + col * chromaPixelStride
-                nv21[offset++] = vBuffer.get(vuIndex)
-                nv21[offset++] = uBuffer.get(vuIndex)
-            }
-        }
-
-        val yuvImage = YuvImage(nv21, ImageFormat.NV21, width, height, null)
-        val outStream = ByteArrayOutputStream()
-        yuvImage.compressToJpeg(Rect(0, 0, width, height), 100, outStream)
-
-        val jpegData = outStream.toByteArray()
-        return BitmapFactory.decodeByteArray(jpegData, 0, jpegData.size)
-    }
-
-    fun rotateToPortrait(bitmap: Bitmap): Bitmap {
-        return if (bitmap.width > bitmap.height) {
-            val matrix = Matrix()
-            matrix.postRotate(90f)
-            Bitmap.createBitmap(
-                bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true
-            )
-        } else {
-            bitmap
-        }
-    }
-
-    fun scaleBitmap(bitmap: Bitmap, width: Int, height: Int): Bitmap {
-        return bitmap.scale(width, height)
     }
 }

--- a/example/lib/examples/ultralytics_integration/detection_service.dart
+++ b/example/lib/examples/ultralytics_integration/detection_service.dart
@@ -69,7 +69,6 @@ class DetectionService {
       final detectedObjects = await _yolo.predict(imageBytes);
       final detectionResult = detectedObjects.toDetectionResult(minBallConfidence: 0.1);
 
-      // TODO: remove after testing
       // saveDetectionToGallery(imageBytes, detectionResult);
 
       return detectionResult;


### PR DESCRIPTION
Rewamped whole snapshot logic, now it uses the PixelCopy method instead of taking the AR image from sceneView, which required postprocessing like scaling, rotations, etc. Also, now the snapshot doesn't block the UI thread due to adding a coroutine in transforming the bitmap to a byte array.